### PR TITLE
Atualização da versão da imagem e variáveis de ambiente

### DIFF
--- a/ELK/docker/docker-compose.yml
+++ b/ELK/docker/docker-compose.yml
@@ -3,8 +3,10 @@ version: '3.1'
 services:
 
   elasticsearch:
-   image: docker.elastic.co/elasticsearch/elasticsearch:6.6.1
+   image: docker.elastic.co/elasticsearch/elasticsearch:7.5.1
    container_name: elasticsearch
+   environment:
+    - discovery.type=single-node
    ports:
     - "9200:9200"
    volumes:
@@ -13,7 +15,7 @@ services:
     - docker-network
 
   kibana:
-   image: docker.elastic.co/kibana/kibana:6.6.1
+   image: docker.elastic.co/kibana/kibana:7.5.1
    container_name: kibana
    ports:
     - "5601:5601"


### PR DESCRIPTION
Uma atualização da versão das imagens se fez necessárias pois as versões descritas nesse arquivo não são mais suportadas.
O container do elastic search continuava dando problema, e após uma pesquisa, a inserção da variável de ambiente discovery.type solucionou o problema.